### PR TITLE
ADCIO-3283) fix: fix color picker panel z-index issue

### DIFF
--- a/src/components/ColorPicker/index.tsx
+++ b/src/components/ColorPicker/index.tsx
@@ -24,6 +24,7 @@ const Base = styled.div`
   box-shadow:
     0px 0px 1px 0px rgba(132, 132, 132, 0.31),
     0px 2px 5px 0px rgba(70, 70, 70, 0.2);
+  z-index: 1;
 
   .react-colorful {
     width: 100%;

--- a/src/components/Input/InputContainer.tsx
+++ b/src/components/Input/InputContainer.tsx
@@ -204,18 +204,18 @@ const InputChildrenWrapper = styled.div`
   position: relative;
 `;
 
-const RightSectionWrapper = styled.div`
+const SectionWrapper = styled.div`
   position: absolute;
-  display: flex;
-  top: 50%;
-  transform: translateY(-50%);
+  height: fit-content;
+  top: 0;
+  bottom: 0;
+  margin: auto;
+`;
+
+const RightSectionWrapper = styled(SectionWrapper)`
   right: 8px;
 `;
 
-const LeftSectionWrapper = styled.div`
-  position: absolute;
-  display: flex;
-  top: 50%;
-  transform: translateY(-50%);
+const LeftSectionWrapper = styled(SectionWrapper)`
   padding-left: 10px;
 `;


### PR DESCRIPTION
## 🔗 Jira Ticket Number

- [ADCIO-3283](https://corca.atlassian.net/browse/ADCIO-3283)
- VILL-

## :recycle: Current situation

<!-- _Describe the current situation. Explain current problems, if there are any. Be as descriptive as possible (e.g., including examples or code snippets)._ -->

<img width="456" alt="image" src="https://github.com/corca-ai/cds/assets/69149030/8bc1c6ca-0cb5-4757-8570-c779fa011421">

[preview 링크](https://adcio-7bgwjmwor-corca.vercel.app/banner/create/)

<br />

**[문제 상황]**
- color picker panel이 layer 아래에 위치하여, 다른 element에 의해 가려지고 있습니다.

**[문제 원인]**
- transform이 적용되어 있더니 color picker에 z-index를 아무리 줘도 레이어 아래에 배치되는 이슈가 있었습니다.
  - transform이나 opacity 같은 일부 css 속성들은 종종 element 자체의 새로운 stacking context에 넣어 layer 이슈가 발생한 것입니다.
  - [참고 링크](https://erwinousy.medium.com/z-index%EA%B0%80-%EB%8F%99%EC%9E%91%ED%95%98%EC%A7%80%EC%95%8A%EB%8A%94-%EC%9D%B4%EC%9C%A0-4%EA%B0%80%EC%A7%80-%EA%B7%B8%EB%A6%AC%EA%B3%A0-%EA%B3%A0%EC%B9%98%EB%8A%94-%EB%B0%A9%EB%B2%95-d5097572b82f)

## :bulb: Proposed solution

<!-- _Describe the proposed solution and changes. How does it affect the project? How does it affect the internal structure (e.g., refactorings)?_ -->

<img width="484" alt="image" src="https://github.com/corca-ai/cds/assets/69149030/2fda1bf5-deec-473a-b148-5f2a01c47426">

[preview 링크](https://adcio-67bnyfy2g-corca.vercel.app/banner/create/)

- transform을 없애고, color picker panel에 z-index를 주어, 레이어 아래에 배치되는 이슈를 해결했습니다.
- 기존 transform 스타일링은 다른 방식으로 수정해주었습니다.
  - [참고 링크](https://levelup.gitconnected.com/dont-use-transform-to-center-element-b378587ad1db)

## :heavy_plus_sign: Additional Information

<!-- _If applicable, provide additional context in this section._ -->

### :test_tube: Testing

<!-- _Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?_ -->

### :technologist: Reviewer Nudging

<!-- _Where should the reviewer start? what is a good entry point?_ -->

<!--
### :art: Design system
- rmp: corca-ai/rmp#
- agent-village: corca-ai/agent-village#
 -->

### :white_check_mark: Checklist

<!-- _What should be done before merging this PR?_ -->

- [x] 수정 사항에 대한 테스트를 마쳤습니다.
- [ ] 관련 노션 문서를 업데이트하였습니다.
- [ ] 디자인 시스템 컴포넌트의 경우 rmp PR 번호 첨부 및 CDS 라벨을 추가하였습니다.
