### PR TITLE
NONE) chore: modify the global.css file to include it in the build output

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,10 +1,10 @@
-import "../src/global.css";
-import "./styles.css";
+import '../src/global.css';
+import './styles.css';
 
 /** @type { import('@storybook/react').Preview } */
 const preview = {
   parameters: {
-    actions: { argTypesRegex: "^on[A-Z].*" },
+    actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This package is a design system used in the service provided by Corca.
 
 Detailed specifications of design system components can be found in the [Storybook document](https://cds-corca.vercel.app/).
 
+## Caution
+
+In order to apply the global.css file in your root file or Next.js \_app file, you must import the `@corca-ai/design-system/dist/global.css` file.
+
 ## Commands
 
 ### Install dependencies

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "packageManager": "pnpm@8.15.4",
   "main": "dist/index.js",
-  "css": "src/global.css",
+  "styles": "src/global.css",
   "repository": "https://github.com/corca-ai/cds",
   "scripts": {
     "build": "tsc && vite build",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "packageManager": "pnpm@8.15.4",
   "main": "dist/index.js",
-  "styles": "src/global.css",
+  "styles": "dist/global.css",
   "repository": "https://github.com/corca-ai/cds",
   "scripts": {
     "build": "tsc && vite build",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "packageManager": "pnpm@8.15.4",
   "main": "dist/index.js",
+  "css": "src/global.css",
   "repository": "https://github.com/corca-ai/cds",
   "scripts": {
     "build": "tsc && vite build",
@@ -60,6 +61,7 @@
     "vite": "^5.1.4",
     "vite-plugin-banner": "^0.7.1",
     "vite-plugin-dts": "^3.7.3",
+    "vite-plugin-static-copy": "^1.0.5",
     "vite-tsconfig-paths": "^4.3.1"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ devDependencies:
   vite-plugin-dts:
     specifier: ^3.7.3
     version: 3.7.3(typescript@4.8.4)(vite@5.1.4)
+  vite-plugin-static-copy:
+    specifier: ^1.0.5
+    version: 1.0.5(vite@5.1.4)
   vite-tsconfig-paths:
     specifier: ^4.3.1
     version: 4.3.1(typescript@4.8.4)(vite@5.1.4)
@@ -9713,6 +9716,19 @@ packages:
       - '@types/node'
       - rollup
       - supports-color
+    dev: true
+
+  /vite-plugin-static-copy@1.0.5(vite@5.1.4):
+    resolution: {integrity: sha512-02k0Rox+buYdEOfeilKZSgs1gXfPf9RjVztZEIYZgVIxjsVZi6AXssjzdi+qW6zYt00d3bq+tpP2voVXN2fKLw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0
+    dependencies:
+      chokidar: 3.6.0
+      fast-glob: 3.3.2
+      fs-extra: 11.2.0
+      picocolors: 1.0.0
+      vite: 5.1.4
     dev: true
 
   /vite-tsconfig-paths@4.3.1(typescript@4.8.4)(vite@5.1.4):

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
-import './global.css';
 export * from './utils';
 export * from './components';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,6 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 export default defineConfig({
   build: {
-    minify: false,
     lib: {
       entry: resolve(__dirname, './src/index.ts'),
       formats: ['es', 'cjs'],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 
 import dts from 'vite-plugin-dts';
 import react from '@vitejs/plugin-react';
-// import { libInjectCss } from 'vite-plugin-lib-inject-css';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 export default defineConfig({
   build: {
@@ -23,7 +23,17 @@ export default defineConfig({
         },
       },
     },
-    minify: false,
   },
-  plugins: [react(), dts()],
+  plugins: [
+    react(),
+    dts(),
+    viteStaticCopy({
+      targets: [
+        {
+          src: ['src/*.css'],
+          dest: resolve(__dirname, 'dist'),
+        },
+      ],
+    }),
+  ],
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,13 @@
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
+
 import dts from 'vite-plugin-dts';
 import react from '@vitejs/plugin-react';
+// import { libInjectCss } from 'vite-plugin-lib-inject-css';
 
 export default defineConfig({
   build: {
+    minify: false,
     lib: {
       entry: resolve(__dirname, './src/index.ts'),
       formats: ['es', 'cjs'],
@@ -20,6 +23,7 @@ export default defineConfig({
         },
       },
     },
+    minify: false,
   },
   plugins: [react(), dts()],
 });


### PR DESCRIPTION
## 🔗 Jira Ticket Number

- ADCIO-
- VILL-

## :recycle: Current situation

<!-- _Describe the current situation. Explain current problems, if there are any. Be as descriptive as possible (e.g., including examples or code snippets)._ -->

### 1. 문제 상황: style inject가 되지 않는 이슈
- 현재 vite 결과물에 global.css 파일이 포함되지 않고 있습니다.
- build 결과물에 import style을 하더라도 style inject가 되지 않아 발생되는 이슈입니다.
  -  참고 링크: https://github.com/vitejs/vite/issues/1579


## :bulb: Proposed solution

<!-- _Describe the proposed solution and changes. How does it affect the project? How does it affect the internal structure (e.g., refactorings)?_ -->

<img width="273" alt="image" src="https://github.com/corca-ai/cds/assets/69149030/7b0a26f1-f6c2-45c4-9df1-675e6f580e93">

- css 파일을 copy해서 빌드 결과물에 그대로 넣게끔 수정했습니다.
- next.js에서 사용할 때 _app.tsx 파일에서 `import '@corca-ai/design-system/dist/global.css'`를 해주시면 됩니다.

## 참고) 작업 시 고려했던 사항

![image](https://github.com/corca-ai/cds/assets/69149030/6255e45b-1652-4e7e-ad15-fc1dc7261d70)

![image](https://github.com/corca-ai/cds/assets/69149030/e7447c58-7525-40c2-ba0a-85fa551e0569)

- 당시엔 빌드 결과물 index.js에 css를 inject하려고 했었습니다.
- index.ts에 css를 포함하게끔 설정을 바꿨더니, 
index.ts에 css를 포함하게끔 설정을 바꿨더니 사진처럼 빌드 결과물에 css 파일이 포함되는 것을 확인했습니다. (* 사진 1 참고)
- 문제는 next.js의 경우 app.tsx가 아닌 곳에서 css파일을 export하면 아래 사진처럼 에러가 발생하게 됩니다. (* 사진 2 참고)
- 따라서 css를 별도의 빌드 결과물로 포함하고, 해당 css 파일을 이용하게끔 구현해주어야 합니다.

### :test_tube: Testing

<!-- _Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?_ -->

### :technologist: Reviewer Nudging

<!-- _Where should the reviewer start? what is a good entry point?_ -->

<!--
### :art: Design system
- rmp: corca-ai/rmp#
- agent-village: corca-ai/agent-village#
 -->

### :white_check_mark: Checklist

<!-- _What should be done before merging this PR?_ -->

- [ ] 수정 사항에 대한 테스트를 마쳤습니다.
- [ ] 관련 노션 문서를 업데이트하였습니다.
- [ ] 디자인 시스템 컴포넌트의 경우 rmp PR 번호 첨부 및 CDS 라벨을 추가하였습니다.
