### PR TITLE
ADCIO-4504) add cds tag publish workflow

### DIFF
--- a/.github/workflows/package-tag-publish.yml
+++ b/.github/workflows/package-tag-publish.yml
@@ -1,0 +1,47 @@
+name: CDS Tag Publish
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8
+
+      - uses: actions/cache@v3
+        id: pnpm-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+      - if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        run: pnpm install --no-frozen-lockfile
+
+      - run: pnpm run build
+
+      - name: Get SLUG and SHA
+        id: tag-meta
+        run: |
+          BRANCH_SLUG=$(echo "${GITHUB_REF#refs/heads/}" | sed 's/\//-/g')
+          SHORT_SHA=$(echo "${GITHUB_SHA::6}")
+          echo "BRANCH_SLUG=${BRANCH_SLUG}" >> $GITHUB_OUTPUT
+          echo "SHORT_SHA=${SHORT_SHA}" >> $GITHUB_OUTPUT
+
+      - uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          tag: ${{ steps.tag-meta.outputs.BRANCH_SLUG }}-${{ steps.tag-meta.outputs.SHORT_SHA }}
+


### PR DESCRIPTION
## 🔗 Jira Ticket Number

- [ADCIO-4504](https://corca.atlassian.net/browse/ADCIO-4504)

## :recycle: Current situation

- 현재 릴리즈 버전만 올리는 배포가 있어서 테스트용 퍼블리시 워크플로우를 추가하려고 함

## :bulb: Proposed solution

- $BRANCH_SLUG-$SHORT_SHA 방식으로 형태를 가져가기로함
  -  tag: ${{ steps.tag-meta.outputs.BRANCH_SLUG }}-${{ steps.tag-meta.outputs.SHORT_SHA }}
- beta-vX.X.X 처럼 버전으로 관리할까도 생각해봤는데, 버전별로 테스트가 목적이 아니라 그냥 브랜치와 커밋 조합으로 가져감


## :heavy_plus_sign: Additional Information

<!-- _If applicable, provide additional context in this section._ -->

### :test_tube: Testing

<!-- _Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?_ -->

### :technologist: Reviewer Nudging

<!-- _Where should the reviewer start? what is a good entry point?_ -->

<!--
### :art: Design system
- rmp: corca-ai/rmp#
- agent-village: corca-ai/agent-village#
 -->

### :white_check_mark: Checklist

<!-- _What should be done before merging this PR?_ -->

- [ ] 수정 사항에 대한 테스트를 마쳤습니다.
- [ ] 관련 노션 문서를 업데이트하였습니다.
- [ ] 디자인 시스템 컴포넌트의 경우 rmp PR 번호 첨부 및 CDS 라벨을 추가하였습니다.
