### PR TITLE
fix: Remove "type" from package.json in deployed version to support older versions

### DIFF
--- a/.github/workflows/package-tag-publish.yml
+++ b/.github/workflows/package-tag-publish.yml
@@ -46,7 +46,8 @@ jobs:
         env:
           TAG_NAME: ${{ steps.tag-meta.outputs.BRANCH_SLUG }}-${{ steps.tag-meta.outputs.TIME }}
         run: |
-          rm -rf src .husky .github .storybook .prettierrc .eslint.config.js pnpm-lock.yaml vercel.json vite.config.js tsconfig.json tsconfig.build.json tsconfig.node.json
+          node ./tools/removePacakgeType.cjs
+          rm -rf tools src .husky .github .storybook .prettierrc .eslint.config.js pnpm-lock.yaml vercel.json vite.config.js tsconfig.json tsconfig.build.json tsconfig.node.json
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           CURRENT_VERSION=$(pnpm pkg get version | tr -d '"')

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": false,
   "version": "0.0.31",
   "packageManager": "pnpm@8.15.4",
+  "type": "module",
   "exports": {
     ".": {
       "require": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "private": false,
   "version": "0.0.31",
   "packageManager": "pnpm@8.15.4",
-  "type": "module",
   "exports": {
     ".": {
       "require": "./dist/index.js",
@@ -51,7 +50,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "icongen": "svgr --out-dir ./src/icon/generated-default --index-template ./tools/svgrIndexTemplate.cjs -- ./src/icon/assets",
-    "prepare": "husky && panda codegen"
+    "prepare": "husky && panda codegen",
+    "prepublishOnly": "node tools/removePacakgeType.cjs"
   },
   "dependencies": {
     "date-fns": "3.3.1",

--- a/tools/removePacakgeType.cjs
+++ b/tools/removePacakgeType.cjs
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 /* eslint-disable @typescript-eslint/no-var-requires */
-
+// app-router로 마이그레이션하면 제거될 코드입니디.
 const fs = require('fs');
 const path = require('path');
 

--- a/tools/removePacakgeType.cjs
+++ b/tools/removePacakgeType.cjs
@@ -1,0 +1,25 @@
+/* eslint-disable no-undef */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const fs = require('fs');
+const path = require('path');
+
+const packagePath = path.resolve(__dirname, '..', 'package.json');
+
+fs.readFile(packagePath, 'utf8', (err, data) => {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  const packageJson = JSON.parse(data);
+  delete packageJson.type;
+
+  fs.writeFile(packagePath, JSON.stringify(packageJson, null, 2), 'utf8', err => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+    console.log('The "type" key has been removed from the package.json file.');
+  });
+});


### PR DESCRIPTION
## 🔗 Jira Ticket Number

- ADCIO-
- VILL-

## :recycle: Current situation

- rmp 저장소에선 "type": "module"이 되면 사용이 불가능함

## :bulb: Proposed solution

- 사용할 때는 "type": "module" 하고 배포된 버전에선 제거함
- 개발은 최신버전으로 진행하고 배포는 하위버전을 지원하기 위함

## :heavy_plus_sign: Additional Information

<!-- _If applicable, provide additional context in this section._ -->

### :test_tube: Testing

<!-- _Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?_ -->

### :technologist: Reviewer Nudging

<!-- _Where should the reviewer start? what is a good entry point?_ -->

<!--
### :art: Design system
- rmp: corca-ai/rmp#
- agent-village: corca-ai/agent-village#
 -->

### :white_check_mark: Checklist

<!-- _What should be done before merging this PR?_ -->

- [ ] 수정 사항에 대한 테스트를 마쳤습니다.
- [ ] 관련 노션 문서를 업데이트하였습니다.
- [ ] 디자인 시스템 컴포넌트의 경우 rmp PR 번호 첨부 및 CDS 라벨을 추가하였습니다.
